### PR TITLE
Upgraded to PyLint Django 2.4.4 + Fixing Linting Errors

### DIFF
--- a/.github/workflows/python-django-app.yml
+++ b/.github/workflows/python-django-app.yml
@@ -35,7 +35,7 @@ jobs:
           pip install -r dev-requirements.txt
       - name: Lint with pylint
         run: |
-          pylint accounts/ core/ data_analysis/ educator/ think_aloud/ tutor/
+          pylint --load-plugins pylint_django --django-settings-module=begintoreason_django.settings accounts/ core/ data_analysis/ educator/ think_aloud/ tutor/
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 pylint==2.6.2
-pylint-django==2.1.0
+pylint-django==2.4.4
 
 -r requirements.txt


### PR DESCRIPTION
Manual upgrade to `pylint-django 2.4.4` and fixing some linting errors.